### PR TITLE
[goose] `For`'s `body` should be `unit -> bool`

### DIFF
--- a/docs/notes/goose.md
+++ b/docs/notes/goose.md
@@ -175,7 +175,7 @@ Definition For: val :=
 
 The Go code `for init; cond; post { body }` is translated (roughly) into `init;; For cond body post`. (Unfortunately this isn't the order of arguments of the notation, which goes `for: cond ; post := body`. The function `For` should be fixed.)
 
-`For` takes three _functions_ as arguments (making it a so-called _higher-order function_): cond, body, and post. You can think of it as having the type `For : (unit -> bool) -> (unit -> unit) -> (unit -> unit) -> unit`, where `#() : unit` is the unit value in GooseLang. (You are welcome to think about these types but we don't actually have a type system for GooseLang, so it's only in your imagination.)
+`For` takes three _functions_ as arguments (making it a so-called _higher-order function_): cond, body, and post. You can think of it as having the type `For : (unit -> bool) -> (unit -> bool) -> (unit -> unit) -> unit`, where `#() : unit` is the unit value in GooseLang. (You are welcome to think about these types but we don't actually have a type system for GooseLang, so it's only in your imagination.)
 
 You might be confused by the `unit` argument each function takes: this is sometimes called a _thunk_ and is needed to prevent evaluating the condition, body, and post until they are needed in the loop. For example, if for the `cond` we passed a `bool` rather than a `unit -> bool` it would be a constant throughout the entire loop. A function that takes a unit isn't evaluated until desired by passing the argument.
 


### PR DESCRIPTION
I found it confusing when reading
> You can think of it as having the type For : (unit -> bool) -> (unit -> unit) -> (unit -> unit) -> unit

because body returns Break (false) and Continue (true) so it should be thought of as `unit -> bool`.

This PR fixes the typo if it is.